### PR TITLE
Fixes to make improve mainline compatiblity

### DIFF
--- a/arch/arm/boot/dts/sun8i-h3.dtsi
+++ b/arch/arm/boot/dts/sun8i-h3.dtsi
@@ -460,17 +460,8 @@
 		};
 
 		gpu@01c40000 {
-			compatible = "arm,mali400";
-			reg = <0x01c40000 0x1000
-			       0x01c41000 0x1000
-			       0x01c42000 0x1000
-			       0x01c43000 0x1000
-			       0x01c44000 0x1000
-			       0x01c45000 0x1000
-			       0x01c48000 0x2000
-			       0x01c4a000 0x2000>;
-			reg-names = "gp", "l2-cache", "pmu", "gp-mmu", "pp0-mmu",
-				    "pp1-mmu", "pp0", "pp1";
+			compatible = "arm,mali-400";
+			reg = <0x01c40000 0x10000>;
 			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL_HIGH>,
 					   <GIC_SPI 98 IRQ_TYPE_LEVEL_HIGH>,
 					   <GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH>,
@@ -478,13 +469,11 @@
 					   <GIC_SPI 101 IRQ_TYPE_LEVEL_HIGH>,
 					   <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH>,
 					   <GIC_SPI 103 IRQ_TYPE_LEVEL_HIGH>;
-			interrupt-names = "gp", "gp-mmu", "pp0", "pp0-mmu", "pmu",
-					  "pp1", "pp1-mmu";
+			interrupt-names = "gp", "gpmmu", "pp0", "pp0mmu", "pmu",
+					  "pp1", "pp1mmu";
 			clocks = <&ccu CLK_BUS_GPU>, <&ccu CLK_GPU>;
-			clock-names = "bus", "gpu";
+			clock-names = "bus", "core";
 			resets = <&ccu RST_BUS_GPU>;
-			reset-names = "ahb";
-			num-pp = <2>;
 		};
 
 		spi0: spi@01c68000 {

--- a/drivers/gpu/drm/lima/Kconfig
+++ b/drivers/gpu/drm/lima/Kconfig
@@ -2,7 +2,7 @@
 config DRM_LIMA
        tristate "LIMA (DRM support for ARM Mali 400 GPU)"
        depends on DRM
-       depends on ARCH_SUNXI
+       depends on ARCH_SUNXI || ARCH_ROCKCHIP
        select INTERVAL_TREE
        help
          DRM driver for ARM Mali 400 GPUs.

--- a/drivers/gpu/drm/lima/lima.h
+++ b/drivers/gpu/drm/lima/lima.h
@@ -114,7 +114,7 @@ struct lima_drm_priv {
 	struct lima_vm *vm;
 };
 
-int lima_device_init(struct lima_device *ldev, struct drm_device *dev);
+int lima_device_init(struct lima_device *ldev);
 void lima_device_fini(struct lima_device *ldev);
 
 int lima_pmu_init(struct lima_pmu *pmu);

--- a/drivers/gpu/drm/lima/lima.h
+++ b/drivers/gpu/drm/lima/lima.h
@@ -31,6 +31,17 @@ enum lima_gpu_type {
 	GPU_MALI400 = 0,
 };
 
+#define LIMA_MALI200_PP_BASE		0x0000
+#define LIMA_MALI200_GP_BASE		0x2000
+#define LIMA_MALI200_MMU_BASE		0x3000
+
+#define LIMA_GP_BASE			0x0000
+#define LIMA_L2_BASE			0x1000
+#define LIMA_PMU_BASE			0x2000
+#define LIMA_GPMMU_BASE			0x3000
+#define LIMA_PPMMU_BASE(_pp)		0x4000 + 0x1000 * (_pp)
+#define LIMA_PP_BASE(_pp)		0x8000 + 0x2000 * (_pp)
+
 struct lima_device;
 
 #define LIMA_IP_MAX_NAME_LEN 32
@@ -38,7 +49,7 @@ struct lima_device;
 struct lima_ip {
 	struct lima_device *dev;
 	char name[LIMA_IP_MAX_NAME_LEN];
-	void __iomem *iomem;
+	u32 offset;
 	int irq;
 };
 
@@ -92,6 +103,7 @@ struct lima_device {
 	struct platform_device *pdev;
 
 	enum lima_gpu_type gpu_type;
+	void __iomem *regs;
 
 	struct clk *clk_bus;
 	struct clk *clk_gpu;

--- a/drivers/gpu/drm/lima/lima_device.c
+++ b/drivers/gpu/drm/lima/lima_device.c
@@ -171,15 +171,11 @@ static int lima_pp_group_init(struct lima_device *dev, int n)
 	return 0;
 }
 
-int lima_device_init(struct lima_device *ldev, struct drm_device *dev)
+int lima_device_init(struct lima_device *ldev)
 {
 	int err;
 	struct device_node *np;
 	u32 num_pp;
-
-	ldev->pdev = dev->platformdev;
-	ldev->dev = &dev->platformdev->dev;
-	ldev->ddev = dev;
 
 	dma_set_coherent_mask(ldev->dev, DMA_BIT_MASK(32));
 

--- a/drivers/gpu/drm/lima/lima_device.c
+++ b/drivers/gpu/drm/lima/lima_device.c
@@ -127,7 +127,7 @@ static int lima_pp_group_init(struct lima_device *dev, int n)
 {
 	int err, i;
 	struct lima_pp *pp;
-	char *pp_name = "pp0", *pp_mmu_name = "pp0-mmu";
+	char pp_name[4], pp_mmu_name[7];
 
 	pp = kzalloc(sizeof(*pp), GFP_KERNEL);
 	if (!pp)
@@ -137,7 +137,8 @@ static int lima_pp_group_init(struct lima_device *dev, int n)
 	for (i = 0; i < n; i++) {
 		struct lima_pp_core *core = pp->core + pp->num_core;
 
-		pp_name[2] = '0' + i; pp_mmu_name[2] = '0' + i;
+		snprintf(pp_name, sizeof(pp_name), "pp%d", i);
+		snprintf(pp_mmu_name, sizeof(pp_mmu_name), "pp%dmmu", i);
 
 		if ((err = lima_init_ip(dev, pp_mmu_name, &core->mmu.ip)) ||
 		    (err = lima_mmu_init(&core->mmu))) {

--- a/drivers/gpu/drm/lima/lima_device.c
+++ b/drivers/gpu/drm/lima/lima_device.c
@@ -11,13 +11,13 @@ static int lima_clk_init(struct lima_device *dev)
 
 	dev->clk_bus = devm_clk_get(dev->dev, "bus");
 	if (IS_ERR(dev->clk_bus)) {
-		dev_err(dev->dev, "get bus clk fail %ld\n", PTR_ERR(dev->clk_bus));
+		dev_err(dev->dev, "get bus clk failed %ld\n", PTR_ERR(dev->clk_bus));
 		return PTR_ERR(dev->clk_bus);
 	}
 
-	dev->clk_gpu = devm_clk_get(dev->dev, "gpu");
+	dev->clk_gpu = devm_clk_get(dev->dev, "core");
 	if (IS_ERR(dev->clk_gpu)) {
-		dev_err(dev->dev, "get gpu clk fail %ld\n", PTR_ERR(dev->clk_gpu));
+		dev_err(dev->dev, "get core clk failed %ld\n", PTR_ERR(dev->clk_gpu));
 		return PTR_ERR(dev->clk_gpu);
 	}
 
@@ -32,7 +32,7 @@ static int lima_clk_init(struct lima_device *dev)
 	if ((err = clk_prepare_enable(dev->clk_gpu)))
 		goto error_out0;
 
-	dev->reset = devm_reset_control_get(dev->dev, "ahb");
+	dev->reset = devm_reset_control_get(dev->dev, NULL);
 	if (IS_ERR(dev->reset)) {
 		err = PTR_ERR(dev->reset);
 		goto error_out1;
@@ -58,9 +58,13 @@ static void lima_clk_fini(struct lima_device *dev)
 }
 
 static int lima_init_ip(struct lima_device *dev, const char *name,
-			struct lima_ip *ip)
+			struct lima_ip *ip, u32 offset)
 {
-	struct resource *res;
+	ip->offset = offset;
+
+	ip->dev = dev;
+	strncpy(ip->name, name, LIMA_IP_MAX_NAME_LEN);
+	ip->name[LIMA_IP_MAX_NAME_LEN - 1] = '\0';
 
 	if (ip->irq == 0) {
 		ip->irq = platform_get_irq_byname(dev->pdev, name);
@@ -69,22 +73,6 @@ static int lima_init_ip(struct lima_device *dev, const char *name,
 			return ip->irq;
 		}
 	}
-
-	res = platform_get_resource_byname(dev->pdev, IORESOURCE_MEM, name);
-	if (!res) {
-		dev_err(dev->dev, "fail to get iomem %s\n", name);
-		return -EINVAL;
-	}
-
-	ip->iomem = devm_ioremap_resource(dev->dev, res);
-	if (IS_ERR(ip->iomem)) {
-		dev_err(dev->dev, "fail to ioremap iomem %s\n", name);
-		return PTR_ERR(ip->iomem);
-	}
-
-	ip->dev = dev;
-	strncpy(ip->name, name, LIMA_IP_MAX_NAME_LEN);
-	ip->name[LIMA_IP_MAX_NAME_LEN - 1] = '\0';
 
 	return 0;
 }
@@ -98,11 +86,11 @@ static int lima_gp_group_init(struct lima_device *dev)
 	if (!gp)
 		return -ENOMEM;
 
-	if ((err = lima_init_ip(dev, "gp-mmu", &gp->mmu.ip)) ||
+	if ((err = lima_init_ip(dev, "gpmmu", &gp->mmu.ip, LIMA_GPMMU_BASE)) ||
 	    (err = lima_mmu_init(&gp->mmu)))
 		goto err_out0;
 
-	if ((err = lima_init_ip(dev, "gp", &gp->ip)) ||
+	if ((err = lima_init_ip(dev, "gp", &gp->ip, LIMA_GP_BASE)) ||
 	    (err = lima_gp_init(gp)))
 		goto err_out1;
 
@@ -123,7 +111,7 @@ err_out0:
 	return err;
 }
 
-static int lima_pp_group_init(struct lima_device *dev, int n)
+static int lima_pp_group_init(struct lima_device *dev)
 {
 	int err, i;
 	struct lima_pp *pp;
@@ -134,19 +122,19 @@ static int lima_pp_group_init(struct lima_device *dev, int n)
 		return -ENOMEM;
 	dev->pp = pp;
 
-	for (i = 0; i < n; i++) {
+	for (i = 0; i < dev->num_pp; i++) {
 		struct lima_pp_core *core = pp->core + pp->num_core;
 
 		snprintf(pp_name, sizeof(pp_name), "pp%d", i);
 		snprintf(pp_mmu_name, sizeof(pp_mmu_name), "pp%dmmu", i);
 
-		if ((err = lima_init_ip(dev, pp_mmu_name, &core->mmu.ip)) ||
+		if ((err = lima_init_ip(dev, pp_mmu_name, &core->mmu.ip, LIMA_PPMMU_BASE(i))) ||
 		    (err = lima_mmu_init(&core->mmu))) {
 			memset(core, 0, sizeof(*core));
 			continue;
 		}
 
-		if ((err = lima_init_ip(dev, pp_name, &core->ip)) ||
+		if ((err = lima_init_ip(dev, pp_name, &core->ip, LIMA_PP_BASE(i))) ||
 		    (err = lima_pp_core_init(core))) {
 			lima_mmu_fini(&core->mmu);
 			memset(core, 0, sizeof(*core));
@@ -156,8 +144,9 @@ static int lima_pp_group_init(struct lima_device *dev, int n)
 		pp->num_core++;
 	}
 
-	if (pp->num_core != n)
-		dev_warn(dev->dev, "bringup pp %d/%d\n", pp->num_core, n);
+	if (pp->num_core != dev->num_pp)
+		dev_warn(dev->dev, "bringup pp %d/%d\n",
+				   pp->num_core, dev->num_pp);
 
 	if (pp->num_core == 0)
 		return -ENODEV;
@@ -176,23 +165,12 @@ int lima_device_init(struct lima_device *ldev)
 {
 	int err;
 	struct device_node *np;
-	u32 num_pp;
 
 	dma_set_coherent_mask(ldev->dev, DMA_BIT_MASK(32));
 
 	ldev->gpu_type = GPU_MALI400;
 
 	np = ldev->dev->of_node;
-	err = of_property_read_u32(np, "num-pp", &num_pp);
-	if (err) {
-		dev_err(ldev->dev, "no num-pp property defined\n");
-		return err;
-	}
-	if (num_pp > LIMA_MAX_PP) {
-		dev_err(ldev->dev, "too many pp %u\n", num_pp);
-		return -EINVAL;
-	}
-	ldev->num_pp = num_pp;
 
 	err = lima_clk_init(ldev);
 	if (err) {
@@ -211,11 +189,12 @@ int lima_device_init(struct lima_device *ldev)
 		err = -ENOMEM;
 		goto err_out;
 	}
-	if ((err = lima_init_ip(ldev, "pmu", &ldev->pmu->ip)) ||
+
+	/* pmu is optional and not always present */
+	if ((err = lima_init_ip(ldev, "pmu", &ldev->pmu->ip, LIMA_PMU_BASE)) ||
 	    (err = lima_pmu_init(ldev->pmu))) {
 		kfree(ldev->pmu);
 		ldev->pmu = NULL;
-		goto err_out;
 	}
 
 	ldev->l2_cache = kzalloc(sizeof(*ldev->l2_cache), GFP_KERNEL);
@@ -224,7 +203,7 @@ int lima_device_init(struct lima_device *ldev)
 		goto err_out;
 	}
 	ldev->l2_cache->ip.irq = -1;
-	if ((err = lima_init_ip(ldev, "l2-cache", &ldev->l2_cache->ip)) ||
+	if ((err = lima_init_ip(ldev, "l2-cache", &ldev->l2_cache->ip, LIMA_L2_BASE)) ||
 	    (err = lima_l2_cache_init(ldev->l2_cache))) {
 		kfree(ldev->l2_cache);
 		ldev->l2_cache = NULL;
@@ -234,7 +213,7 @@ int lima_device_init(struct lima_device *ldev)
 	if ((err = lima_gp_group_init(ldev)))
 		goto err_out;
 
-	if ((err = lima_pp_group_init(ldev, num_pp)))
+	if ((err = lima_pp_group_init(ldev)))
 		goto err_out;
 
 	return 0;

--- a/drivers/gpu/drm/lima/lima_drv.c
+++ b/drivers/gpu/drm/lima/lima_drv.c
@@ -144,42 +144,6 @@ static int lima_ioctl_gem_wait(struct drm_device *dev, void *data, struct drm_fi
 	return lima_gem_wait(file, args->handle, args->op, args->timeout_ns);
 }
 
-static int lima_drm_driver_load(struct drm_device *dev, unsigned long flags)
-{
-	struct lima_device *ldev;
-	int err;
-
-	ldev = kzalloc(sizeof(*ldev), GFP_KERNEL);
-	if (!ldev)
-		return -ENOMEM;
-
-	dev->dev_private = (void *)ldev;
-
-	err = lima_device_init(ldev, dev);
-	if (err) {
-		dev_err(&dev->platformdev->dev, "Fatal error during GPU init\n");
-		goto err0;
-	}
-
-	platform_set_drvdata(dev->platformdev, dev);
-
-	return 0;
-
-err0:
-	kfree(ldev);
-	return err;
-}
-
-static int lima_drm_driver_unload(struct drm_device *dev)
-{
-	struct lima_device *ldev = to_lima_dev(dev);
-
-	lima_device_fini(ldev);
-	kfree(ldev);
-	dev->dev_private = NULL;
-	return 0;
-}
-
 static int lima_drm_driver_open(struct drm_device *dev, struct drm_file *file)
 {
 	int err;
@@ -237,8 +201,6 @@ static const struct file_operations lima_drm_driver_fops = {
 
 static struct drm_driver lima_drm_driver = {
 	.driver_features    = DRIVER_RENDER | DRIVER_GEM,
-	.load		    = lima_drm_driver_load,
-	.unload             = lima_drm_driver_unload,
 	.open               = lima_drm_driver_open,
 	.postclose          = lima_drm_driver_postclose,
 	.ioctls             = lima_drm_driver_ioctls,
@@ -255,12 +217,56 @@ static struct drm_driver lima_drm_driver = {
 
 static int lima_pdev_probe(struct platform_device *pdev)
 {
-	return drm_platform_init(&lima_drm_driver, pdev);
+	struct lima_device *ldev;
+	struct drm_device *ddev;
+	int err;
+
+	ldev = devm_kzalloc(&pdev->dev, sizeof(*ldev), GFP_KERNEL);
+	if (!ldev)
+		return -ENOMEM;
+
+	ldev->pdev = pdev;
+	ldev->dev = &pdev->dev;
+
+	platform_set_drvdata(pdev, ldev);
+
+	/* Allocate and initialize the DRM device. */
+	ddev = drm_dev_alloc(&lima_drm_driver, &pdev->dev);
+	if (IS_ERR(ddev)) {
+		lima_device_fini(ldev);
+		return PTR_ERR(ddev);
+	}
+
+	ddev->dev_private = ldev;
+	ldev->ddev = ddev;
+
+	err = lima_device_init(ldev);
+	if (err) {
+		dev_err(&pdev->dev, "Fatal error during GPU init\n");
+		return err;
+	}
+
+	/*
+	 * Register the DRM device with the core and the connectors with
+	 * sysfs.
+	 */
+	err = drm_dev_register(ddev, 0);
+	if (err < 0) {
+		lima_device_fini(ldev);
+		return PTR_ERR(ddev);
+	}
+
+	return 0;
 }
 
 static int lima_pdev_remove(struct platform_device *pdev)
 {
-	drm_put_dev(platform_get_drvdata(pdev));
+	struct lima_device *ldev = platform_get_drvdata(pdev);
+	struct drm_device *ddev = ldev->ddev;
+
+	drm_dev_unregister(ddev);
+	drm_dev_unref(ddev);
+	lima_device_fini(ldev);
 	return 0;
 }
 

--- a/drivers/gpu/drm/lima/lima_gp.c
+++ b/drivers/gpu/drm/lima/lima_gp.c
@@ -98,8 +98,8 @@
 	 LIMA_GP_IRQ_MASK_ERROR)
 
 
-#define gp_write(reg, data) writel(data, gp->ip.iomem + LIMA_GP_##reg)
-#define gp_read(reg) readl(gp->ip.iomem + LIMA_GP_##reg)
+#define gp_write(reg, data) writel(data, gp->ip.dev->regs + gp->ip.offset + LIMA_GP_##reg)
+#define gp_read(reg) readl(gp->ip.dev->regs + gp->ip.offset + LIMA_GP_##reg)
 
 static irqreturn_t lima_gp_irq_handler(int irq, void *data)
 {

--- a/drivers/gpu/drm/lima/lima_l2_cache.c
+++ b/drivers/gpu/drm/lima/lima_l2_cache.c
@@ -16,8 +16,8 @@
 #define LIMA_L2_CACHE_PERFCNT_SRC1	 0x0028
 #define LIMA_L2_CACHE_ERFCNT_VAL1	 0x002C
 
-#define l2_cache_write(reg, data) writel(data, l2_cache->ip.iomem + LIMA_L2_CACHE_##reg)
-#define l2_cache_read(reg) readl(l2_cache->ip.iomem + LIMA_L2_CACHE_##reg)
+#define l2_cache_write(reg, data) writel(data, l2_cache->ip.dev->regs + l2_cache->ip.offset + LIMA_L2_CACHE_##reg)
+#define l2_cache_read(reg) readl(l2_cache->ip.dev->regs + l2_cache->ip.offset + LIMA_L2_CACHE_##reg)
 
 static int lima_l2_cache_wait_idle(struct lima_l2_cache *l2_cache)
 {

--- a/drivers/gpu/drm/lima/lima_mmu.c
+++ b/drivers/gpu/drm/lima/lima_mmu.c
@@ -87,8 +87,8 @@ int lima_mmu_init(struct lima_mmu *mmu)
 	if (err)
 		return err;
 
-	err = devm_request_irq(dev->dev, mmu->ip.irq, lima_mmu_irq_handler, 0,
-			       mmu->ip.name, mmu);
+	err = devm_request_irq(dev->dev, mmu->ip.irq, lima_mmu_irq_handler,
+			       IRQF_SHARED, mmu->ip.name, mmu);
 	if (err) {
 		dev_err(dev->dev, "mmu %s fail to request irq\n", mmu->ip.name);
 		return err;

--- a/drivers/gpu/drm/lima/lima_mmu.c
+++ b/drivers/gpu/drm/lima/lima_mmu.c
@@ -28,8 +28,8 @@
 #define   LIMA_MMU_INT_READ_BUS_ERROR       0x02
 #define LIMA_MMU_INT_STATUS		  0x0020
 
-#define mmu_write(reg, data) writel(data, mmu->ip.iomem + LIMA_MMU_##reg)
-#define mmu_read(reg) readl(mmu->ip.iomem + LIMA_MMU_##reg)
+#define mmu_write(reg, data) writel(data, mmu->ip.dev->regs + mmu->ip.offset + LIMA_MMU_##reg)
+#define mmu_read(reg) readl(mmu->ip.dev->regs + mmu->ip.offset + LIMA_MMU_##reg)
 
 #define lima_mmu_send_command(command, condition)	     \
 ({							     \

--- a/drivers/gpu/drm/lima/lima_pmu.c
+++ b/drivers/gpu/drm/lima/lima_pmu.c
@@ -12,8 +12,8 @@
 #define   LIMA_PMU_INT_CMD_MASK            (1 << 0)
 #define LIMA_PMU_SW_DELAY                  0x1C
 
-#define pmu_write(reg, data) writel(data, pmu->ip.iomem + LIMA_PMU_##reg)
-#define pmu_read(reg) readl(pmu->ip.iomem + LIMA_PMU_##reg)
+#define pmu_write(reg, data) printk("writing 0x%x\n", (int)(pmu->ip.dev->regs + pmu->ip.offset + LIMA_PMU_##reg)); writel(data, pmu->ip.dev->regs + pmu->ip.offset + LIMA_PMU_##reg)
+#define pmu_read(reg) printk("reading 0x%x\n", (int)(pmu->ip.dev->regs + pmu->ip.offset + LIMA_PMU_##reg)); readl(pmu->ip.dev->regs + pmu->ip.offset + LIMA_PMU_##reg)
 
 static int lima_pmu_wait_cmd(struct lima_pmu *pmu)
 {

--- a/drivers/gpu/drm/lima/lima_pp.c
+++ b/drivers/gpu/drm/lima/lima_pp.c
@@ -205,8 +205,8 @@ int lima_pp_core_init(struct lima_pp_core *core)
 	if (err)
 		return err;
 
-	err = devm_request_irq(dev->dev, core->ip.irq, lima_pp_core_irq_handler, 0,
-			       core->ip.name, core);
+	err = devm_request_irq(dev->dev, core->ip.irq, lima_pp_core_irq_handler,
+			       IRQF_SHARED, core->ip.name, core);
 	if (err) {
 		dev_err(dev->dev, "pp %s fail to request irq\n", core->ip.name);
 		return err;

--- a/drivers/gpu/drm/lima/lima_pp.c
+++ b/drivers/gpu/drm/lima/lima_pp.c
@@ -80,8 +80,8 @@
 	 LIMA_PP_IRQ_END_OF_FRAME          | \
 	 LIMA_PP_IRQ_MASK_ERROR)
 
-#define pp_write(reg, data) writel(data, core->ip.iomem + LIMA_PP_##reg)
-#define pp_read(reg) readl(core->ip.iomem + LIMA_PP_##reg)
+#define pp_write(reg, data) writel(data, core->ip.dev->regs + core->ip.offset + LIMA_PP_##reg)
+#define pp_read(reg) readl(core->ip.dev->regs + core->ip.offset + LIMA_PP_##reg)
 
 static irqreturn_t lima_pp_core_irq_handler(int irq, void *data)
 {
@@ -159,12 +159,12 @@ static void lima_pp_core_start_task(struct lima_pp_core *core, int index,
 	frame->frame.fragment_stack_address = frame->fragment_stack_address[index];
 
 	for (i = 0; i < num_frame_reg; i++)
-		writel(frame_reg[i], core->ip.iomem + LIMA_PP_FRAME + i * 4);
+		writel(frame_reg[i], core->ip.dev->regs + core->ip.offset + LIMA_PP_FRAME + i * 4);
 
 	for (i = 0; i < 3; i++) {
 		u32 *wb_reg = (void *)&frame->wb[i];
 		for (j = 0; j < num_wb_reg; j++)
-			writel(wb_reg[j], core->ip.iomem + LIMA_PP_WB(i) + j * 4);
+			writel(wb_reg[j], core->ip.dev->regs + core->ip.offset + LIMA_PP_WB(i) + j * 4);
 	}
 
 	pp_write(CTRL, LIMA_PP_CTRL_START_RENDERING);


### PR DESCRIPTION
Hi,

I've started playing with your code on Rockchip SoCs using Mali400 GPUs and as I'm working with the mainline kernel as base, I stumbled over some areas for improvement :-) . 

The biggest is of course the devicetree binding. Utgard Malis have an approved binding in the mainline kernel [0] that differs quite a bit from the older out-of-tree variants. So I've modified the device init to conform to the mainline one and have been able to bring up the gpus on both the rk3188 and rk3036 socs. So far I've only concentrated on the kernel side to get the driver to come up at all :-) .

The lima_ip stuff now also looks a bit much, with only the interrupt actually being handled there, so I'm planning on simplifying this a bit more in the future.

In my branch [1] I'm also sitting on some more patches that are needed for newer kernel versions to work at all (prefixed with FORWARD).

So, let me know what you think :-)

Thanks
Heiko

[0] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/devicetree/bindings/gpu/arm,mali-utgard.txt
[1] https://github.com/mmind/linux-rockchip/commits/devel/lima-yuq