### PR TITLE
lima: add prime import support

### DIFF
--- a/drivers/gpu/drm/lima/lima.h
+++ b/drivers/gpu/drm/lima/lima.h
@@ -149,6 +149,9 @@ int lima_gem_submit(struct drm_file *file, struct lima_sched_pipe *pipe,
 		    struct drm_lima_gem_submit_bo *bos, u32 nr_bos,
 		    void *frame, u32 *fence);
 int lima_gem_wait(struct drm_file *file, u32 handle, u32 op, u64 timeout_ns);
+struct drm_gem_object *lima_gem_prime_import_sg_table(struct drm_device *dev,
+						      struct dma_buf_attachment *attach,
+						      struct sg_table *sgt);
 
 unsigned long lima_timeout_to_jiffies(u64 timeout_ns);
 

--- a/drivers/gpu/drm/lima/lima_drv.c
+++ b/drivers/gpu/drm/lima/lima_drv.c
@@ -1,5 +1,6 @@
 #include <linux/module.h>
 #include <linux/of_platform.h>
+#include <drm/drm_prime.h>
 
 #include "lima.h"
 
@@ -200,7 +201,7 @@ static const struct file_operations lima_drm_driver_fops = {
 };
 
 static struct drm_driver lima_drm_driver = {
-	.driver_features    = DRIVER_RENDER | DRIVER_GEM,
+	.driver_features    = DRIVER_RENDER | DRIVER_GEM | DRIVER_PRIME,
 	.open               = lima_drm_driver_open,
 	.postclose          = lima_drm_driver_postclose,
 	.ioctls             = lima_drm_driver_ioctls,
@@ -213,6 +214,10 @@ static struct drm_driver lima_drm_driver = {
 	.date               = "20170325",
 	.major              = 1,
 	.minor              = 0,
+
+	.prime_fd_to_handle = drm_gem_prime_fd_to_handle,
+	.gem_prime_import   = drm_gem_prime_import,
+	.gem_prime_import_sg_table = lima_gem_prime_import_sg_table,
 };
 
 static int lima_pdev_probe(struct platform_device *pdev)


### PR DESCRIPTION
This patchset adds prime support to the lima kernel driver.
With this, it is possible to import buffers allocated in the display driver and exported with prime, enabling lima to render to a buffer that is being scanned to an output (such as HDMI).

Most of the initial commits in this series were not in linux 4.13 and were backported because they allow the sun4i-drm display driver to be used in the Allwinner A20, which is my test target. They define the reference device tree nodes that I used to port to the A20, along with a clock infrastructure change for the A20 which I found to be necessary to reduce the amount of work to make the sun4i-drm bindings to work on the A20.

This was finally tested with this application: https://github.com/enunes/mesa-test-programs/blob/master/gbm-bo-test.c
It is also necessary to have the mesa-lima patches to enable prime support there.