### PR TITLE
Mali450 support

### DIFF
--- a/drivers/gpu/drm/lima/lima.h
+++ b/drivers/gpu/drm/lima/lima.h
@@ -29,6 +29,7 @@
 
 enum lima_gpu_type {
 	GPU_MALI400 = 0,
+	GPU_MALI450,
 };
 
 struct lima_device;
@@ -66,6 +67,7 @@ struct lima_gp {
 	struct lima_ip ip;
 	struct lima_mmu mmu;
 	struct lima_sched_pipe pipe;
+	struct lima_l2_cache *l2_cache;
 
 	int task;
 	bool async_reset;
@@ -83,6 +85,7 @@ struct lima_pp {
 	struct lima_pp_core core[LIMA_MAX_PP];
 	int num_core;
 	struct lima_sched_pipe pipe;
+	struct lima_l2_cache *l2_cache;
 	atomic_t task;
 };
 

--- a/drivers/gpu/drm/lima/lima_device.c
+++ b/drivers/gpu/drm/lima/lima_device.c
@@ -174,8 +174,6 @@ int lima_device_init(struct lima_device *ldev)
 
 	dma_set_coherent_mask(ldev->dev, DMA_BIT_MASK(32));
 
-	ldev->gpu_type = GPU_MALI400;
-
 	np = ldev->dev->of_node;
 
 	err = lima_clk_init(ldev);

--- a/drivers/gpu/drm/lima/lima_device.c
+++ b/drivers/gpu/drm/lima/lima_device.c
@@ -8,8 +8,21 @@
 #define LIMA_L2_BASE           0x1000
 #define LIMA_PMU_BASE          0x2000
 #define LIMA_GPMMU_BASE        0x3000
-#define LIMA_PPMMU_BASE(i)     (0x4000 + 0x1000 * (i))
-#define LIMA_PP_BASE(i)        (0x8000 + 0x2000 * (i))
+#define LIMA_PPMMU_BASE(i)     ((i < 4) ? 0x4000 + 0x1000 * (i) : \
+					  0x1C000 + 0x1000 * (i - 4))
+#define LIMA_PP_BASE(i)        ((i < 4) ? 0x8000 + 0x2000 * (i) : \
+					  0x28000 + 0x2000 * (i - 4))
+
+/* Separate L2-caches per group on Mali450 */
+#define LIMA450_GPL2_BASE      0x10000
+#define LIMA450_PP03L2_BASE    0x01000
+#define LIMA450_PP47L2_BASE    0x11000
+
+#define LIMA_BCAST_BASE        0x13000
+#define LIMA_PPBCAST_BASE      0x16000
+#define LIMA_PPBCASTMMU_BASE   0x15000
+#define LIMA_DLBU_BASE         0x14000
+#define LIMA_DMA_BASE          0x12000
 
 static int lima_clk_init(struct lima_device *dev)
 {

--- a/drivers/gpu/drm/lima/lima_drv.c
+++ b/drivers/gpu/drm/lima/lima_drv.c
@@ -19,6 +19,9 @@ static int lima_ioctl_info(struct drm_device *dev, void *data, struct drm_file *
 	case GPU_MALI400:
 		info->gpu_id = LIMA_INFO_GPU_MALI400;
 		break;
+	case GPU_MALI450:
+		info->gpu_id = LIMA_INFO_GPU_MALI450;
+		break;
 	default:
 		return -ENODEV;
 	}
@@ -70,6 +73,7 @@ static int lima_ioctl_gem_submit(struct drm_device *dev, void *data, struct drm_
 
 	switch (ldev->gpu_type) {
 	case GPU_MALI400:
+	case GPU_MALI450:
 		if (args->pipe == LIMA_PIPE_GP) {
 			if (args->frame_size != sizeof(struct drm_lima_m400_gp_frame))
 				return -EINVAL;
@@ -103,6 +107,7 @@ static int lima_ioctl_gem_submit(struct drm_device *dev, void *data, struct drm_
 
 	switch (ldev->gpu_type) {
 	case GPU_MALI400:
+	case GPU_MALI450:
 		if (args->pipe == LIMA_PIPE_PP) {
 			struct drm_lima_m400_pp_frame *f = frame;
 			if (f->num_pp > ldev->pp->num_core) {
@@ -283,6 +288,7 @@ static int lima_pdev_remove(struct platform_device *pdev)
 
 static const struct of_device_id dt_match[] = {
 	{ .compatible = "arm,mali-400", .data = (void *)GPU_MALI400 },
+	{ .compatible = "arm,mali-450", .data = (void *)GPU_MALI450 },
 	{}
 };
 MODULE_DEVICE_TABLE(of, dt_match);

--- a/drivers/gpu/drm/lima/lima_drv.c
+++ b/drivers/gpu/drm/lima/lima_drv.c
@@ -235,6 +235,7 @@ static int lima_pdev_probe(struct platform_device *pdev)
 
 	ldev->pdev = pdev;
 	ldev->dev = &pdev->dev;
+	ldev->gpu_type = (enum lima_gpu_type)of_device_get_match_data(&pdev->dev);
 
 	platform_set_drvdata(pdev, ldev);
 
@@ -281,7 +282,7 @@ static int lima_pdev_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id dt_match[] = {
-	{ .compatible = "arm,mali-400" },
+	{ .compatible = "arm,mali-400", .data = (void *)GPU_MALI400 },
 	{}
 };
 MODULE_DEVICE_TABLE(of, dt_match);

--- a/drivers/gpu/drm/lima/lima_sched.c
+++ b/drivers/gpu/drm/lima/lima_sched.c
@@ -243,7 +243,12 @@ static int lima_sched_pipe_worker(void *param)
 		 * 3. can we reduce the calling of this function because all
 		 *    GP/PP use the same L2 cache
 		 */
-		lima_l2_cache_flush(pipe->mmu[0]->ip.dev->l2_cache);
+		if (pipe->mmu[0]->ip.dev->gpu_type == GPU_MALI450) {
+			lima_l2_cache_flush(pipe->mmu[0]->ip.dev->gp->l2_cache);
+			lima_l2_cache_flush(pipe->mmu[0]->ip.dev->pp->l2_cache);
+		} else {
+			lima_l2_cache_flush(pipe->mmu[0]->ip.dev->l2_cache);
+		}
 
 		for (i = 0; i < pipe->num_mmu; i++)
 			lima_mmu_switch_vm(pipe->mmu[i], task->vm, false);

--- a/include/uapi/drm/lima_drm.h
+++ b/include/uapi/drm/lima_drm.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 #define LIMA_INFO_GPU_MALI400 0x00
+#define LIMA_INFO_GPU_MALI450 0x01
 
 struct drm_lima_info {
 	__u32 gpu_id;  /* out */


### PR DESCRIPTION
As one of the commits states, Mali450 does have some more blocks (load balancer, dma, broadcast and separate l2 caches), but seems to work somewhat nicely with only the basics like the L2 set up.

This can of course be expanded to support the additional features later on, but with this basic support I can at least run the "kmscube -d" demo on _both_ Mali400 (rk3188-radxarock) as well as on my rk3328-rock64 board [the one from Pine64] using a Mali450MP2.

On the kernel-side I also end up with:
[   15.829968] lima ff300000.gpu: bus rate = 163840000
[   15.830424] lima ff300000.gpu: mod rate = 163840000
[   15.831940] lima ff300000.gpu: found 2 PPs
[   15.832351] lima ff300000.gpu: fail to get irq pmu
[   15.832801] lima ff300000.gpu: no PMU present
[   15.833459] lima ff300000.gpu: l2 cache 8K, 4-way, 64byte cache line, 128bit external bus
[   15.834344] lima ff300000.gpu: gp - mali450 version major 0 minor 0
[   15.838300] lima ff300000.gpu: l2 cache 64K, 4-way, 64byte cache line, 128bit external bus
[   15.839317] lima ff300000.gpu: pp0 - mali450 version major 0 minor 0
[   15.840096] lima ff300000.gpu: pp1 - mali450 version major 0 minor 0
[   15.841510] [drm] Initialized lima 1.0.0 20170325 for ff300000.gpu on minor 0
