### PR TITLE
handle Mali450 pmu correctly

### DIFF
--- a/drivers/gpu/drm/lima/lima_pmu.c
+++ b/drivers/gpu/drm/lima/lima_pmu.c
@@ -5,6 +5,16 @@
 #define   LIMA_PMU_POWER_GP0_MASK          (1 << 0)
 #define   LIMA_PMU_POWER_L2_MASK           (1 << 1)
 #define   LIMA_PMU_POWER_PP_MASK(i)        (1 << (2 + i))
+
+/*
+ * On Mali450 each block automatically starts up its corresponding L2
+ * and the PPs are not fully independent controllable.
+ * Instead PP0, PP1-3 and PP4-7 can be turned on or off.
+ */
+#define   LIMA450_PMU_POWER_PP0_MASK       BIT(1)
+#define   LIMA450_PMU_POWER_PP13_MASK      BIT(2)
+#define   LIMA450_PMU_POWER_PP47_MASK      BIT(3)
+
 #define LIMA_PMU_STATUS                    0x08
 #define LIMA_PMU_INT_MASK                  0x0C
 #define LIMA_PMU_INT_RAWSTAT               0x10
@@ -48,9 +58,22 @@ int lima_pmu_init(struct lima_pmu *pmu)
 	stat = pmu_read(STATUS);
 
 	/* power up all ip */
-	mask = LIMA_PMU_POWER_GP0_MASK | LIMA_PMU_POWER_L2_MASK;
-	for (i = 0; i < dev->num_pp; i++)
-		mask |= LIMA_PMU_POWER_PP_MASK(i);
+	switch (dev->gpu_type) {
+	case GPU_MALI400:
+		mask = LIMA_PMU_POWER_GP0_MASK | LIMA_PMU_POWER_L2_MASK;
+		for (i = 0; i < dev->num_pp; i++)
+			mask |= LIMA_PMU_POWER_PP_MASK(i);
+		break;
+	case GPU_MALI450:
+		mask = LIMA_PMU_POWER_GP0_MASK | LIMA450_PMU_POWER_PP0_MASK;
+		if (dev->num_pp > 1)
+			mask |= LIMA450_PMU_POWER_PP13_MASK;
+		if (dev->num_pp > 4)
+			mask |= LIMA450_PMU_POWER_PP47_MASK;
+		break;
+	default:
+		return -ENODEV;
+	}
 
 	if (stat & mask) {
 		pmu_write(POWER_UP, stat & mask);


### PR DESCRIPTION
Rockchip Utgard Malis generally don't implement the PMU block, so it looks like I forgot to adapt the power-up sequence for the recent Mali450 support.

As can be seen in the diff, the handling is slightly different, was put together by looking at the GPL'ed mali/common/mali_pm.c and is obviously compile-tested only as my rk3328 always has everything turned on.