### PR TITLE
Exynos4 support

### DIFF
--- a/arch/arm/boot/dts/exynos4.dtsi
+++ b/arch/arm/boot/dts/exynos4.dtsi
@@ -720,6 +720,39 @@
 		status = "disabled";
 	};
 
+	gpu: gpu@13000000 {
+		compatible = "arm,mali-400";
+		reg = <0x13000000 0x30000>;
+		power-domains = <&pd_g3d>;
+
+		/*
+		 * Propagate VPLL output clock to SCLK_G3D and
+		 * ensure that the DIV_G3D divider is 1.
+		 */
+		assigned-clocks = <&clock CLK_MOUT_G3D1>, <&clock CLK_MOUT_G3D>,
+				  <&clock CLK_FOUT_VPLL>, <&clock CLK_SCLK_G3D>;
+		assigned-clock-parents = <&clock CLK_SCLK_VPLL>,
+					 <&clock CLK_MOUT_G3D1>;
+		assigned-clock-rates = <0>, <0>, <160000000>, <160000000>;
+
+		clocks = <&clock CLK_SCLK_G3D>, <&clock CLK_G3D>;
+		clock-names = "bus", "core";
+
+		interrupts = <GIC_SPI 118 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 119 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 121 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 122 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 123 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 124 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 125 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 126 IRQ_TYPE_LEVEL_HIGH>,
+				<GIC_SPI 127 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "ppmmu0", "ppmmu1", "ppmmu2", "ppmmu3",
+				  "gpmmu", "pp0", "pp1", "pp2", "pp3", "gp";
+		status = "disabled";
+	};
+
 	tmu: tmu@100C0000 {
 		#include "exynos4412-tmu-sensor-conf.dtsi"
 	};

--- a/drivers/gpu/drm/lima/Kconfig
+++ b/drivers/gpu/drm/lima/Kconfig
@@ -2,7 +2,7 @@
 config DRM_LIMA
        tristate "LIMA (DRM support for ARM Mali 400 GPU)"
        depends on DRM
-       depends on ARCH_SUNXI || ARCH_ROCKCHIP
+       depends on ARCH_SUNXI || ARCH_ROCKCHIP || ARCH_EXYNOS
        select INTERVAL_TREE
        help
          DRM driver for ARM Mali 400 GPUs.

--- a/drivers/gpu/drm/lima/lima.h
+++ b/drivers/gpu/drm/lima/lima.h
@@ -100,6 +100,7 @@ struct lima_device {
 	struct clk *clk_bus;
 	struct clk *clk_gpu;
 	struct reset_control *reset;
+	struct regulator *regulator;
 
 	struct lima_pmu *pmu;
 


### PR DESCRIPTION
offscreen kmscube and gbm-surface both tested and working on exynos4412. 

I tested this on 4.15, and have only verified that it compiles on 4.13.

One thing to note is: exynos-drm exposes /dev/dri/renderD128 (I guess for 2D acceleration), so lima uses /dev/dri/renderD129 - so gbm-surface has to be modified accordingly.