### PR TITLE
drm/lima: include pagemap.h for implicit declared mapping_set_gfp_mask

### DIFF
--- a/drivers/gpu/drm/lima/lima_gem.c
+++ b/drivers/gpu/drm/lima/lima_gem.c
@@ -1,5 +1,6 @@
 #include <drm/drmP.h>
 #include <linux/dma-mapping.h>
+#include <linux/pagemap.h>
 
 #include "lima.h"
 #include "lima_gem.h"


### PR DESCRIPTION
While arm32 seems to get this include implicitly, on arm64 it is missing, so results in a compile-time error.
Fix that by adding the missing include.