### PR TITLE
arm64/dts: add switch-delay for meson mali

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi
@@ -278,6 +278,7 @@
 			"pp2", "ppmmu2";
 		clocks = <&clkc CLKID_CLK81>, <&clkc CLKID_MALI>;
 		clock-names = "bus", "core";
+		switch-delay = <0xffff>;
 
 		/*
 		 * Mali clocking is provided by two identical clock paths


### PR DESCRIPTION
Meson mali GPU operate in high clock frequency, need
this value be high to work in a stable state.