### PR TITLE
drm/lima: don't use GFP_KERNEL under spin lock

### DIFF
--- a/drivers/gpu/drm/lima/lima_ctx.c
+++ b/drivers/gpu/drm/lima/lima_ctx.c
@@ -39,17 +39,17 @@ int lima_ctx_create(struct lima_device *dev, struct lima_ctx_mgr *mgr, u32 *id)
 			goto err_out0;
 	}
 
+	idr_preload(GFP_KERNEL);
 	spin_lock(&mgr->lock);
-	err = idr_alloc(&mgr->handles, ctx, 1, 0, GFP_KERNEL);
-	if (err < 0)
-		goto err_out1;
+	err = idr_alloc(&mgr->handles, ctx, 1, 0, GFP_ATOMIC);
 	spin_unlock(&mgr->lock);
+	idr_preload_end();
+	if (err < 0)
+		goto err_out0;
 
 	*id = err;
 	return 0;
 
-err_out1:
-	spin_unlock(&mgr->lock);
 err_out0:
 	for (i--; i >= 0; i--)
 		lima_sched_context_fini(dev->pipe[i], ctx->context + i);


### PR DESCRIPTION
Try to preallocate the memory with idr_prealloc(GFP_KERNEL)
and change the allocation flags under spin lock.

Based on commit 2c8468dcf830
("net: sched: don't use GFP_KERNEL under spin lock")

Signed-off-by: Alban Browaeys <alban.browaeys@gmail.com>

---

This fixes an error when attempting a weston launch:
```
[ 5802.900308] BUG: sleeping function called from invalid context at mm/slab.h:420
[ 5802.902146] in_atomic(): 1, irqs_disabled(): 0, pid: 5897, name: weston
[ 5802.908605] 1 lock held by weston/5897:
[ 5802.912504]  #0:  (&(&mgr->lock)->rlock){+.+.}, at: [<1cf4a11c>] lima_ctx_create+0x9c/0x144 [lima]
[ 5802.921428] Preemption disabled at:
[ 5802.921453] [<bf112a38>] lima_ctx_create+0x9c/0x144 [lima]
[ 5802.930312] CPU: 1 PID: 5897 Comm: weston Tainted: G           O     4.16.0-rc5-debug+ #153
[ 5802.938635] Hardware name: SAMSUNG EXYNOS (Flattened Device Tree)
[ 5802.944711] Backtrace: 
[ 5802.947150] [<c010f0c8>] (dump_backtrace) from [<c010f3dc>] (show_stack+0x20/0x24)
[ 5802.954695]  r7:c0e7b13c r6:00000000 r5:20010053 r4:c0e7b13c
[ 5802.960340] [<c010f3bc>] (show_stack) from [<c0930c9c>] (dump_stack+0xa0/0xcc)
[ 5802.967546] [<c0930bfc>] (dump_stack) from [<c0165ec0>] (___might_sleep+0x1f8/0x2d4)
[ 5802.975267]  r9:e491df28 r8:014000c0 r7:ebcca000 r6:bf112a38 r5:ffffe000 r4:00000000
[ 5802.982994] [<c0165cc8>] (___might_sleep) from [<c016600c>] (__might_sleep+0x70/0xa8)
[ 5802.990805]  r7:00000001 r6:00000000 r5:000001a4 r4:c0bf4768
[ 5802.996451] [<c0165f9c>] (__might_sleep) from [<c0300e44>] (kmem_cache_alloc+0x154/0x450)
[ 5803.004604]  r6:00000000 r5:00000000 r4:014000c0
[ 5803.009208] [<c0300cf0>] (kmem_cache_alloc) from [<c0938b50>] (radix_tree_node_alloc.constprop.6+0x5c/0xf8)
[ 5803.018928]  r10:00000001 r9:e491df28 r8:e491df24 r7:00000001 r6:00000000 r5:00000000
[ 5803.026737]  r4:e491df24
[ 5803.029258] [<c0938af4>] (radix_tree_node_alloc.constprop.6) from [<c093969c>] (idr_get_free+0x1e4/0x35c)
[ 5803.038803]  r7:00000001 r6:00000000 r5:00000000 r4:00000000
[ 5803.044449] [<c09394b8>] (idr_get_free) from [<c093395c>] (idr_alloc_u32+0x68/0x128)
[ 5803.052172]  r10:00000001 r9:00000000 r8:eb9c5c00 r7:ebccbd9c r6:00000000 r5:00000000
[ 5803.059981]  r4:e491df24
[ 5803.062503] [<c09338f4>] (idr_alloc_u32) from [<c0933a54>] (idr_alloc+0x38/0x80)
[ 5803.069879]  r8:e491df04 r7:eb9c5c08 r6:eb9c5c00 r5:ebccbe60 r4:ed1f9a10
[ 5803.076580] [<c0933a1c>] (idr_alloc) from [<bf112a58>] (lima_ctx_create+0xbc/0x144 [lima])
[ 5803.084831] [<bf11299c>] (lima_ctx_create [lima]) from [<bf10d0e4>] (lima_ioctl_ctx+0x4c/0x58 [lima])
[ 5803.094010]  r10:c0086447 r9:ebccbe5c r8:bf10d098 r7:00000021 r6:00000000 r5:edeef800
[ 5803.101819]  r4:eb809c00
[ 5803.104349] [<bf10d098>] (lima_ioctl_ctx [lima]) from [<c05b49c8>] (drm_ioctl_kernel+0x70/0xc0)
[ 5803.113020] [<c05b4958>] (drm_ioctl_kernel) from [<c05b4d90>] (drm_ioctl+0x1f8/0x414)
[ 5803.120831]  r9:eb809c00 r8:00000008 r7:00000008 r6:ebccbe5c r5:bf11335c r4:c0e084c8
[ 5803.128558] [<c05b4b98>] (drm_ioctl) from [<c0332be0>] (do_vfs_ioctl+0xb4/0x9ec)
[ 5803.135934]  r10:00000020 r9:00000011 r8:00000011 r7:c033358c r6:e3d7c140 r5:ede52fa8
[ 5803.143743]  r4:befc6398
[ 5803.146264] [<c0332b2c>] (do_vfs_ioctl) from [<c033358c>] (SyS_ioctl+0x74/0x84)
[ 5803.153554]  r10:00000020 r9:00000011 r8:befc6398 r7:c0086447 r6:00000000 r5:e3d7c140
[ 5803.161364]  r4:e3d7c140
[ 5803.163886] [<c0333518>] (SyS_ioctl) from [<c010118c>] (__sys_trace_return+0x0/0x10)
[ 5803.171607] Exception stack(0xebccbfa8 to 0xebccbff0)
[ 5803.176643] bfa0:                   009445f0 befc6398 00000011 c0086447 befc6398 00000000
[ 5803.184807] bfc0: 009445f0 befc6398 c0086447 00000036 00941950 00000000 00000000 00000002
[ 5803.192960] bfe0: b6ed308c befc6374 b6ebc337 b6c610b8
[ 5803.197996]  r9:ebcca000 r8:c01011c4 r7:00000036 r6:c0086447 r5:befc6398 r4:009445f0

```